### PR TITLE
Fix vite config for production build / 本番ビルド用にvite configを修正

### DIFF
--- a/appRoot/vite.config.js
+++ b/appRoot/vite.config.js
@@ -3,6 +3,9 @@ import laravel from 'laravel-vite-plugin';
 import tailwindcss from '@tailwindcss/vite';
 import fs from 'fs';
 
+// ローカル開発環境でのみSSLファイルの存在をチェック
+const isLocal = process.env.NODE_ENV !== 'production' && fs.existsSync('../ssl/localhost.key') && fs.existsSync('../ssl/localhost.crt');
+
 export default defineConfig({
     plugins: [
         laravel({
@@ -14,10 +17,12 @@ export default defineConfig({
     server: {
         host: '0.0.0.0',
         port: 5173,
-        https: {
-            key: fs.readFileSync('../ssl/localhost.key'),
-            cert: fs.readFileSync('../ssl/localhost.crt'),
-        },
+        ...(isLocal && {
+            https: {
+                key: fs.readFileSync('../ssl/localhost.key'),
+                cert: fs.readFileSync('../ssl/localhost.crt'),
+            },
+        }),
         hmr: {
             host: 'localhost',
             port: 5173,


### PR DESCRIPTION
## Summary / 概要

Fixed the Vite configuration to support production builds by making SSL certificate loading conditional on the development environment only.

本番ビルドをサポートするため、SSL証明書の読み込みを開発環境でのみ行うようにVite設定を修正しました。

## Changes / 変更内容

- Added environment check to conditionally load SSL certificates only in local development
- SSL configuration is now skipped when `NODE_ENV` is `production` or when SSL files don't exist
- This prevents build failures in production environments where SSL certificate files are not available

- ローカル開発環境でのみSSL証明書を読み込むように環境チェックを追加
- `NODE_ENV`が`production`の場合、またはSSLファイルが存在しない場合はSSL設定をスキップ
- SSL証明書ファイルが利用できない本番環境でのビルドエラーを防止

## Technical Details / 技術詳細

- Modified `appRoot/vite.config.js` to use conditional SSL configuration
- Added `isLocal` flag that checks both `NODE_ENV` and SSL file existence
- Used spread operator to conditionally include HTTPS configuration

- 条件付きSSL設定を使用するように`appRoot/vite.config.js`を修正
- `NODE_ENV`とSSLファイルの存在を両方チェックする`isLocal`フラグを追加
- スプレッド演算子を使用してHTTPS設定を条件付きで含めるようにした

## Test Plan / テスト計画

- [x] Verified development environment still works with HTTPS
- [x] Confirmed production build completes successfully without SSL files

- [x] 開発環境でHTTPSが引き続き機能することを確認
- [x] SSLファイルなしで本番ビルドが正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)