### PR TITLE
Fix HTTPS mixed content issues in production and proxy environments

### DIFF
--- a/appRoot/app/Providers/AppServiceProvider.php
+++ b/appRoot/app/Providers/AppServiceProvider.php
@@ -19,6 +19,14 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        // 本番環境でHTTPSを強制
+        if (app()->environment('production')) {
+            \Illuminate\Support\Facades\URL::forceScheme('https');
+        }
+
+        // Renderなどのプロキシ環境対応
+        if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
+            \Illuminate\Support\Facades\URL::forceScheme('https');
+        }
     }
 }

--- a/appRoot/bootstrap/app.php
+++ b/appRoot/bootstrap/app.php
@@ -11,7 +11,8 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        // Renderなどのプロキシ環境でHTTPSを正しく認識
+        $middleware->trustProxies(at: '*');
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //


### PR DESCRIPTION
## Summary / 概要

Fixed HTTPS mixed content issues by enforcing HTTPS scheme in production and proxy environments.

本番環境およびプロキシ環境でHTTPSスキームを強制することで、HTTPS mixed content問題を修正しました。

## Changes / 変更内容

### 1. AppServiceProvider.php
- Force HTTPS scheme in production environment / 本番環境でHTTPSスキームを強制
- Add support for proxy environments (e.g., Render) by detecting `X-Forwarded-Proto` header / `X-Forwarded-Proto`ヘッダーを検出してプロキシ環境（Renderなど）に対応

### 2. bootstrap/app.php
- Configure middleware to trust proxies for proper HTTPS detection in proxy environments / プロキシ環境でHTTPSを正しく認識するためにプロキシを信頼するミドルウェアを設定

## Background / 背景

When deploying Laravel applications behind reverse proxies or in production environments, mixed content issues can occur where some resources are loaded over HTTP instead of HTTPS, causing security warnings and blocked content.

リバースプロキシの背後やプロダクション環境でLaravelアプリケーションをデプロイする際、一部のリソースがHTTPSではなくHTTPで読み込まれるmixed content問題が発生し、セキュリティ警告やコンテンツのブロックが発生する可能性があります。

## Solution / 解決方法

- Force HTTPS URLs in production environment / 本番環境でHTTPS URLを強制
- Detect and handle `X-Forwarded-Proto` header for proxy environments / プロキシ環境用に`X-Forwarded-Proto`ヘッダーを検出して処理
- Trust proxies to correctly identify HTTPS requests / HTTPSリクエストを正しく識別するためにプロキシを信頼

## Testing / テスト方法

1. Deploy to production or proxy environment / 本番環境またはプロキシ環境にデプロイ
2. Verify all resources load over HTTPS / すべてのリソースがHTTPS経由で読み込まれることを確認
3. Check browser console for no mixed content warnings / ブラウザコンソールでmixed contentの警告がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)