### PR TITLE
Fix release workflow shell syntax for release notes handling

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -255,9 +255,9 @@ jobs:
           
           # リリースノートの内容を出力変数に設定
           {
-            echo 'release_notes<<EOF'
+            echo 'release_notes<<RELEASE_EOF'
             cat release_notes.md
-            echo EOF
+            echo RELEASE_EOF
           } >> $GITHUB_OUTPUT
 
       - name: Create tag
@@ -274,21 +274,22 @@ jobs:
         run: |
           NEW_VERSION="${{ steps.next_version.outputs.new_version }}"
           
+          # リリースノートをJSONエスケープ
+          RELEASE_BODY=$(echo '${{ steps.release_notes.outputs.release_notes }}' | jq -Rs .)
+          
           # リリースを作成
           curl -X POST \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/repos/${{ github.repository }}/releases" \
-            -d @- << EOF
-          {
-            "tag_name": "$NEW_VERSION",
-            "target_commitish": "main",
-            "name": "$NEW_VERSION",
-            "body": $(echo '${{ steps.release_notes.outputs.release_notes }}' | jq -Rs .),
-            "draft": false,
-            "prerelease": false
-          }
-          EOF
+            -d "{
+              \"tag_name\": \"$NEW_VERSION\",
+              \"target_commitish\": \"main\",
+              \"name\": \"$NEW_VERSION\",
+              \"body\": $RELEASE_BODY,
+              \"draft\": false,
+              \"prerelease\": false
+            }"
 
       - name: Summary
         run: |


### PR DESCRIPTION
## Summary / 変更の概要

Fix shell syntax errors in the manual release workflow to properly handle release notes and JSON formatting.

リリースワークフローのシェル構文エラーを修正し、リリースノートとJSONフォーマットを適切に処理できるようにしました。

## Purpose / 変更の目的

The previous implementation had issues with:
- HEREDOC delimiter conflicts when using `EOF` multiple times in the same script
- Potential shell parsing errors when embedding HEREDOC within curl's `-d` flag

These issues could cause the release workflow to fail when creating GitHub releases.

以前の実装では以下の問題がありました：
- スクリプト内で`EOF`を複数回使用した際のHEREDOCデリミタの競合
- curlの`-d`フラグ内でHEREDOCを使用した際のシェルパースエラーの可能性

これらの問題により、GitHubリリース作成時にワークフローが失敗する可能性がありました。

## Main Changes / 主な変更内容

1. Changed HEREDOC delimiter from `EOF` to `RELEASE_EOF` to avoid conflicts with curl's HEREDOC
2. Refactored the release creation logic to pre-escape release notes as JSON and pass them directly without HEREDOC
3. Improved the curl command structure to use inline JSON instead of HEREDOC for better reliability

主な変更：
1. HEREDOCデリミタを`EOF`から`RELEASE_EOF`に変更し、curlのHEREDOCとの競合を回避
2. リリース作成ロジックを改善し、リリースノートを事前にJSONエスケープしてHEREDOCを使わずに直接渡す形式に変更
3. curlコマンドの構造を改善し、HEREDOCの代わりにインラインJSONを使用することで信頼性を向上

## Testing / 動作確認

N/A (Workflow changes - will be verified in CI/CD execution)

N/A（ワークフロー修正のため、CI/CD実行時に検証予定）

## Notes / 備考

This fix ensures that the manual release workflow can reliably create GitHub releases with properly formatted release notes.

この修正により、手動リリースワークフローが適切にフォーマットされたリリースノートを使用してGitHubリリースを確実に作成できるようになります。