### PR TITLE
Fix Summary step multiline shell variable quote issue

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -320,4 +320,4 @@ jobs:
           fi
           
           echo "### Release Notes Preview:" >> $GITHUB_STEP_SUMMARY
-          echo '${{ steps.release_notes.outputs.release_notes }}' >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.release_notes.outputs.release_notes }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary / 概要

Fixed shell variable quoting in GitHub Actions workflow Summary step to properly handle multiline release notes.

GitHub ActionsワークフローのSummary stepにおいて、複数行のリリースノートを正しく処理できるようにシェル変数のクォートを修正しました。

## Changes / 変更内容

- Changed single quotes to double quotes for `release_notes` output variable in Summary step
- This allows GitHub Actions variable expansion to work correctly with multiline content

- Summary stepの`release_notes`出力変数のクォートをシングルクォートからダブルクォートに変更
- これによりGitHub Actionsの変数展開が複数行コンテンツで正しく動作するようになります

## Technical Details / 技術詳細

Single quotes prevent variable expansion in shell, while double quotes allow it. This is critical for multiline content in GitHub Actions outputs.

シェルではシングルクォートは変数展開を防ぎますが、ダブルクォートは変数展開を許可します。これはGitHub Actionsの出力における複数行コンテンツにとって重要です。

## Test Plan / テスト計画

- [ ] Verify release workflow runs successfully
- [ ] Confirm release notes are properly displayed in workflow summary
- [ ] Check that multiline content is correctly expanded

- [ ] リリースワークフローが正常に実行されることを確認
- [ ] リリースノートがワークフローサマリーに正しく表示されることを確認
- [ ] 複数行コンテンツが正しく展開されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)